### PR TITLE
Set django-reversion's version to 1.9.3 because borgcollector does not support new version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.7.4
 django-suit
 django-extensions
 django-codemirror-widget
-django-reversion
+django-reversion==1.9.3
 django-redis
 SQLAlchemy
 six


### PR DESCRIPTION
support the new version