### PR TITLE
1.Use different json file for different action to fix a bug:

### DIFF
--- a/harvest/harveststates.py
+++ b/harvest/harveststates.py
@@ -712,18 +712,19 @@ class SubmitToVersionControl(HarvestState):
             elif st.geography_columns:
                 json_out["bbox"] = st.geography_columns[0][2]
 
+        file_name = p.output_filename_abs('publish')
         #create the dir if required
-        if not os.path.exists(os.path.dirname(p.output_filename_abs)):
-            os.makedirs(os.path.dirname(p.output_filename_abs))
+        if not os.path.exists(os.path.dirname(file_name)):
+            os.makedirs(os.path.dirname(file_name))
 
-        with open(p.output_filename_abs, "wb") as output:
+        with open(file_name, "wb") as output:
             json.dump(json_out, output, indent=4)
 
         # Try and add file to repository, if no changes then continue
         hg = hglib.open(BorgConfiguration.BORG_STATE_REPOSITORY)
         try:
-            hg.add(files=[p.output_filename_abs])
-            hg.commit(include=[p.output_filename_abs],addremove=True, user=BorgConfiguration.BORG_STATE_USER, message="{} - updated {}.{}".format(p.job_batch_id, p.workspace.name, p.name))
+            hg.add(files=[file_name])
+            hg.commit(include=[file_name],addremove=True, user=BorgConfiguration.BORG_STATE_USER, message="{} - updated {}.{}".format(p.job_batch_id, p.workspace.name, p.name))
         except hglib.error.CommandError as e:
             if e.out != "nothing changed\n":
                 return (HarvestStateOutcome.failed, self.get_exception_message())

--- a/layergroup/models.py
+++ b/layergroup/models.py
@@ -188,20 +188,21 @@ class LayerGroup(models.Model,ResourceStatusManagement,SignalEnable):
 
         return (included_publishs,included_layers,included_groups)
         
-    @property
-    def json_filename(self):
-        return os.path.join(self.workspace.publish_channel.name,"layergroups", "{}.{}.json".format(self.workspace.name, self.name))
+    def json_filename(self,action='publish'):
+        if action == 'publish':
+            return os.path.join(self.workspace.publish_channel.name,"layergroups", "{}.{}.json".format(self.workspace.name, self.name))
+        else:
+            return os.path.join(self.workspace.publish_channel.name,"layergroups", "{}.{}.{}.json".format(self.workspace.name, self.name,action))
 
-    @property
-    def json_filename_abs(self):
-        return os.path.join(BorgConfiguration.BORG_STATE_REPOSITORY, self.json_filename)
+    def json_filename_abs(self,action='publish'):
+        return os.path.join(BorgConfiguration.BORG_STATE_REPOSITORY, self.json_filename(action))
 
     def unpublish(self):
         """
          remove store's json reference (if exists) from the repository,
          return True if store is removed for repository; return false, if layers does not existed in repository.
         """
-        json_filename = self.json_filename_abs;
+        json_filename = self.json_filename_abs('publish');
         if os.path.exists(json_filename):
             #file exists, layers is published, remove it.
             try_set_push_owner("layergroup")
@@ -224,7 +225,7 @@ class LayerGroup(models.Model,ResourceStatusManagement,SignalEnable):
         """
         publish store's json reference (if exists) to the repository;
         """
-        json_filename = self.json_filename_abs;
+        json_filename = self.json_filename_abs('publish');
 
         try_set_push_owner("layergroup")
         hg = None
@@ -281,7 +282,7 @@ class LayerGroup(models.Model,ResourceStatusManagement,SignalEnable):
         if self.status not in [ResourceStatus.PUBLISHED,ResourceStatus.UPDATED]:
             #layer is not published, no need to empty gwc
             return
-        json_filename = self.json_filename_abs;
+        json_filename = self.json_filename_abs('empty_gwc');
         try_set_push_owner("layergroup")
         hg = None
         try:


### PR DESCRIPTION
Only the latest action will be kept if multiple actions share the same json file.
for example,
A. Publish a wms layer. In the mercurial repository, the json file
contains the data to publish a wms layer

B. Empty the gwc for this layer. Now, in the mercurial repository, the json file only have the meta data to
empty gwc.

C. Resynchronize a slave server from the beginning.
we will find that wms layer can't be created and also the empty gwc job
will be failed because of non existed wms layer.

2. Implement a "empty_gwc" feature for publish