### PR TITLE
1. Remote other related json files when publish a feture or wms layer or

### DIFF
--- a/borg_utils/resource_status.py
+++ b/borg_utils/resource_status.py
@@ -6,12 +6,12 @@ class ResourceStatus(object):
     PUBLISHED = 'Published' #published
     UNPUBLISHED = 'Unpublished' #not published now; 
 
-    PUBLISH = 'Publish' #a intermediate status
-    UNPUBLISH = 'Unpublish' #a intermediate status
-    CASCADE_UNPUBLISH = 'CascadeUnpublish' #a intermediate status
-    DEPENDENT_PUBLISH = 'DependentPublish' #a intermediate status, used to automatically publish the resource dependent by the current resource.
-    CASCADE_PUBLISH = 'CascadePublish' #a intermediate status, used to automatically publish the children resource ownd by the current resource
-    SIDE_PUBLISH = 'SidePublish' #a intermediate status, used to automatically publish the resource affected by the current resource
+    PUBLISH = 'Publish' #an intermediate status
+    UNPUBLISH = 'Unpublish' #an intermediate status
+    CASCADE_UNPUBLISH = 'CascadeUnpublish' #an intermediate status, used to automatically unpulish the descendant resources 
+    DEPENDENT_PUBLISH = 'DependentPublish' #an intermediate status, used to automatically publish the parent resources.
+    CASCADE_PUBLISH = 'CascadePublish' #an intermediate status, used to automatically publish the descendant resources
+    SIDE_PUBLISH = 'SidePublish' #an intermediate status, used to automatically publish the resource affected by the current resource
 
 class ResourceStatusManagement(object):
     """

--- a/harvest/harveststates.py
+++ b/harvest/harveststates.py
@@ -696,6 +696,7 @@ class SubmitToVersionControl(HarvestState):
         json_out["title"] = p.title
         json_out["abstract"] = p.abstract
         json_out["auth_level"] = p.workspace.auth_level
+        json_out["publish_time"] = timezone.localtime(timezone.now()).strftime("%Y-%m-%d %H:%M:%S.%f")
 
         if p.geoserver_setting:
             json_out["geoserver_setting"] = json.loads(p.geoserver_setting)
@@ -724,7 +725,16 @@ class SubmitToVersionControl(HarvestState):
         hg = hglib.open(BorgConfiguration.BORG_STATE_REPOSITORY)
         try:
             hg.add(files=[file_name])
-            hg.commit(include=[file_name],addremove=True, user=BorgConfiguration.BORG_STATE_USER, message="{} - updated {}.{}".format(p.job_batch_id, p.workspace.name, p.name))
+
+            #remove meta json file and empty gwc json file
+            files =[p.output_filename_abs(action) for action in ['meta','empty_gwc'] ]
+            files =[ f for f in files if os.path.exists(f)]
+            if files:
+                hg.remove(files=files)
+
+            files.append(file_name)
+
+            hg.commit(include=files,addremove=True, user=BorgConfiguration.BORG_STATE_USER, message="{} - updated {}.{}".format(p.job_batch_id, p.workspace.name, p.name))
         except hglib.error.CommandError as e:
             if e.out != "nothing changed\n":
                 return (HarvestStateOutcome.failed, self.get_exception_message())

--- a/tablemanager/models.py
+++ b/tablemanager/models.py
@@ -2184,7 +2184,6 @@ class Publish(Transform,SignalEnable):
         try_set_push_owner("publish")
         hg = None
         try:
-            hg = hglib.open(BorgConfiguration.BORG_STATE_REPOSITORY)
             json_file = self.output_filename_abs('meta')
 
             # Write JSON output file
@@ -2200,7 +2199,7 @@ class Publish(Transform,SignalEnable):
             json_out["title"] = self.title
             json_out["action"] = 'meta'
             json_out["abstract"] = self.abstract
-            json_out["publish_time"] = timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+            json_out["publish_time"] = timezone.localtime(timezone.now()).strftime("%Y-%m-%d %H:%M:%S.%f")
             json_out["auth_level"] = self.workspace.auth_level
 
             if self.geoserver_setting:
@@ -2215,6 +2214,7 @@ class Publish(Transform,SignalEnable):
             with open(json_file, "wb") as output:
                 json.dump(json_out, output, indent=4)
 
+            hg = hglib.open(BorgConfiguration.BORG_STATE_REPOSITORY)
             hg.commit(include=[json_file],addremove=True, user=BorgConfiguration.BORG_STATE_USER, message="Update feature's meta data {}.{}".format(self.workspace.name, self.name))
 
             increase_committed_changes()
@@ -2251,7 +2251,7 @@ class Publish(Transform,SignalEnable):
             json_out["name"] = self.table_name
             json_out["workspace"] = self.workspace.name
             json_out["action"] = "empty_gwc"
-            json_out["empty_time"] = timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+            json_out["publish_time"] = timezone.localtime(timezone.now()).strftime("%Y-%m-%d %H:%M:%S.%f")
             json_out["auth_level"] = self.workspace.auth_level
 
             #create the dir if required


### PR DESCRIPTION
layergroup.

2. Use the property "publish_time" to log the time when publish the job.